### PR TITLE
Fixed sync issue between server / client when it comes to projectiles

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -260,33 +260,26 @@ window.addEventListener("load", function () {
             _collision.forEach(function (proj) {
                 delete entities['projectile-' + proj.nonce];
             })
-
         },
         'projectile-fire': function (_projectile) {
             let cached_projectile = entities['projectile-' + _projectile.nonce];
             if (cached_projectile) {
-                cached_projectile.x = _projectile.x;
-                cached_projectile.y = _projectile.y;
-                cached_projectile.rotationDegrees = _projectile.rotationDegrees;
-                cached_projectile.wobble = _projectile.wobble;
-                cached_projectile.color = _projectile.color;
-                cached_projectile.wobbleRotation = _projectile.wobbleRotation;
+                copyProps(_projectile, cached_projectile);
             } else {
-                addEntity(new Projectile(_projectile.nonce, _projectile.x, _projectile.y, _projectile.rotationDegrees, _projectile.fireTime, _projectile.playerNonce), 'projectile-' + _projectile.nonce)
+                let newProjectile = new Projectile(_projectile.nonce, _projectile.x, _projectile.y, _projectile.rotationDegrees, _projectile.fireTime, _projectile.playerNonce);
+                copyProps(_projectile, newProjectile);
+                addEntity(newProjectile, 'projectile-' + _projectile.nonce)
             }
         },
         'update-chosen-room': function (room) {
             serverTime = room.serverTime;
             room.actors.forEach(function (server_player) {
                 if (server_player.nonce !== player.nonce) {
-                    var cached_player = entities['enemy-' + server_player.nonce];
-
+                    let cached_player = entities['enemy-' + server_player.nonce];
                     if (cached_player) {
-                        cached_player.x = server_player.x;
-                        cached_player.y = server_player.y;
-                        cached_player.rotationDegrees = server_player.rotationDegrees;
+                        //TODO: Better Handle this color
+                        copyProps(server_player, cached_player);
                     } else {
-                        console.log("Adding enemy" + server_player);
                         addEntity(new Enemy(server_player.x, server_player.y), 'enemy-' + server_player.nonce);
                     }
                 }

--- a/public/client.js
+++ b/public/client.js
@@ -277,7 +277,6 @@ window.addEventListener("load", function () {
                 if (server_player.nonce !== player.nonce) {
                     let cached_player = entities['enemy-' + server_player.nonce];
                     if (cached_player) {
-                        //TODO: Better Handle this color
                         copyProps(server_player, cached_player);
                     } else {
                         addEntity(new Enemy(server_player.x, server_player.y), 'enemy-' + server_player.nonce);

--- a/public/server.js
+++ b/public/server.js
@@ -123,7 +123,7 @@ module.exports = {
 
         socket.on("join", function () {
             selectedRoom = rooms[0];
-            var actor = new Actor(0, 0, null);
+            var actor = new Actor(0, 0, 'red');
             actor.nonce = currentPlayerNonce;
             selectedRoom.joinPlayer(actor);
             socket.join('room_' + selectedRoom.nonce);

--- a/public/shared.js
+++ b/public/shared.js
@@ -198,9 +198,6 @@ class Projectile extends Entity {
         this._getDeltaTime = function () {
             return ((serverTime - this.fireTime) / tick_rate);
         };
-        this.onClientTick = function() {
-
-        };
         this.onTick = function () {
             this.x = this._startingX + (this.speed * Math.cos(this.wobbleRotation * Math.PI / 180) * this._getDeltaTime());
             this.y = this._startingY + (this.speed * Math.sin(this.wobbleRotation * Math.PI / 180) * this._getDeltaTime());

--- a/public/shared.js
+++ b/public/shared.js
@@ -6,6 +6,10 @@ function forObj(obj, fn) {
     })
 }
 
+function copyProps(src, dest) {
+    Object.keys(src).forEach((key) => dest[key] = src[key]);
+}
+
 let abs = Math.abs;
 const map_height = 5000;
 const map_width = 5000;
@@ -193,6 +197,9 @@ class Projectile extends Entity {
 
         this._getDeltaTime = function () {
             return ((serverTime - this.fireTime) / tick_rate);
+        };
+        this.onClientTick = function() {
+
         };
         this.onTick = function () {
             this.x = this._startingX + (this.speed * Math.cos(this.wobbleRotation * Math.PI / 180) * this._getDeltaTime());


### PR DESCRIPTION
Added a cool little client utility method for copying server DTO properties to our local properties. Then used this to fix the weird syncing issues on projectiles.

It turns out the constructor of a projectile assigns a random wobble and a random speed to a given projectile. Because we new the projectile on both the server and the client, any previous values that the server assigned are overwritten by the clients constructor. To fix this I use the new utility method to overwrite any reassigned properties to new instances of projectile so they match the servers properties and so the server and client projectiles will be in sync with one another.